### PR TITLE
Fix gpg call to avoid word splitting

### DIFF
--- a/pos-instalacao-pop.sh
+++ b/pos-instalacao-pop.sh
@@ -183,7 +183,7 @@ mkdir /home/$USER/Documentos/.cofre
 touch /home/$USER/Documentos/.cofre/.senhas.txt
 echo "Digite a senha para proteger o arquivo de senhas"
 read -s senha
-echo $senha | gpg --batch --yes --passphrase-fd 0 -c /home/$USER/Documentos/.cofre/.senhas.txt
+echo "$senha" | gpg --batch --yes --passphrase-fd 0 -c /home/$USER/Documentos/.cofre/.senhas.txt
 
 # Solicita se deseja configurar o google drive e solicita o email e a senha e cria um diretorio na pasta de documentos do usuario chamado google_drive sincronizada com o gdrive
 


### PR DESCRIPTION
## Summary
- prevent word splitting in `gpg` command

## Testing
- `bash -n pos-instalacao-pop.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f79b54150832c9d4a9c54e87abaab