### PR TITLE
Fix Google Drive setup prompt

### DIFF
--- a/pos-instalacao-pop.sh
+++ b/pos-instalacao-pop.sh
@@ -185,14 +185,13 @@ echo "Digite a senha para proteger o arquivo de senhas"
 read -s senha
 echo $senha | gpg --batch --yes --passphrase-fd 0 -c /home/$USER/Documentos/.cofre/.senhas.txt
 
-# Solicita se deseja configurar o google drive e solicita o email e a senha e cria um diretorio na pasta de documentos do usuario chamado google_drive sincronizada com o gdrive
-
+# Solicita se deseja configurar o Google Drive, e caso afirmativo, realiza a configuração
+read -p "Deseja configurar o Google Drive? (y/n): " install_google_drive
 if [ "$install_google_drive" == "y" ]; then
     echo "Digite o email do Google Drive"
     read email
     echo "Digite a senha do Google Drive"
     read -s senha
-    read -p "Deseja configurar o Google Drive? (y/n): " install_google_drive
     read -p "cliente_id: " client_id
     read -p "client_secret: " client_secret
     mkdir /home/$USER/Documentos/google_drive


### PR DESCRIPTION
## Summary
- ensure Google Drive question is asked before the conditional
- run Google Drive setup only if confirmed

## Testing
- `bash -n pos-instalacao-pop.sh`
- `shellcheck pos-instalacao-pop.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f79aea83c832cbf7879ed2440c6c3